### PR TITLE
Fix multi-line comments, and add alternate "comment" prefix

### DIFF
--- a/Simula-DEMOS.YAML-tmLanguage
+++ b/Simula-DEMOS.YAML-tmLanguage
@@ -7,7 +7,8 @@ uuid: 00e33390-a82e-4e24-bdb0-290d21180d29
 
 patterns:
 - name: comment.line.character.simulademos
-  match: \!.+?;
+  begin: (?i:\!|\bcomment)
+  end: ;
 - name: string.quoted.single.simulademos
   match: \'.+?\'
 - name: string.quoted.double.simulademos

--- a/Simula-DEMOS.tmLanguage
+++ b/Simula-DEMOS.tmLanguage
@@ -11,8 +11,10 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>match</key>
-			<string>\!.+?;</string>
+			<key>begin</key>
+			<string>(?i:\!|\bcomment)</string>
+			<key>end</key>
+			<string>;</string>
 			<key>name</key>
 			<string>comment.line.character.simulademos</string>
 		</dict>


### PR DESCRIPTION
Add support for multi-line comments and comments started by the alternate prefix "comment" instead of "!"